### PR TITLE
Update VS Code engine requirement to 1.75.0 and modernize dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/pagebrooks/vscode-hl7.git"
     },
     "engines": {
-        "vscode": "^0.10.x"
+        "vscode": "^1.75.0"
     },
     "categories": [
         "Languages",
@@ -59,7 +59,8 @@
             "title": "HL7: Tokenize Line"
         }]
     },
-    "devdependencies": {
-        "vscode": "0.10.x"
+    "devDependencies": {
+        "@types/vscode": "^1.75.0",
+        "@vscode/test-electron": "^2.3.0"
     }
 }


### PR DESCRIPTION
## Summary
This PR updates the VS Code extension to target a modern version of VS Code (1.75.0) and modernizes the development dependencies to use current testing and type definition packages.

## Key Changes
- **Engine requirement**: Updated `vscode` engine from `^0.10.x` to `^1.75.0` to target a modern VS Code version
- **Dev dependencies**: Replaced the outdated `vscode` package with:
  - `@types/vscode` (^1.75.0) for proper TypeScript type definitions
  - `@vscode/test-electron` (^2.3.0) for modern extension testing
- **Package.json formatting**: Fixed `devdependencies` casing to `devDependencies` (correct npm convention)

## Implementation Details
These changes align the extension with current VS Code extension development best practices. The new dependencies provide:
- Proper TypeScript support through official type definitions
- Modern test infrastructure using the official VS Code test runner
- Compatibility with VS Code versions from 1.75.0 onwards

This is a significant version bump that drops support for very old VS Code versions (0.10.x) in favor of a stable, modern baseline.